### PR TITLE
CP-1182 Release route.dart 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/angular/route.dart.git"
   },
   "devDependencies": {
-    "karma" : "~0.12.0",
-    "karma-dart" : "~0.2.6",
+    "karma": "~0.12.0",
+    "karma-dart": "~0.2.6",
     "karma-sauce-launcher": "^0.2.3",
     "karma-script-launcher": "*",
     "karma-chrome-launcher": "~0.1.3",
@@ -23,5 +23,6 @@
       "url": "https://github.com/angular/route.dart/blob/master/LICENSE"
     }
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "version": "0.7.0"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: route_hierarchical
-version: 0.6.2
+version: 0.7.0
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1182

JIRA and PR's included in this release: 

 CP-1183  - refactor to permit HistoryProviders and in memory history + dart_dev  - https://github.com/Workiva/route.dart/pull/1

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/route.dart/compare/0.6.1...CP-1182_release_0.7.0
