### PR TITLE
CP-1210 fix skipped async test failure

### DIFF
--- a/test/click_handler_test.dart
+++ b/test/click_handler_test.dart
@@ -110,12 +110,14 @@ main() {
       var router = new Router(
           useFragment: true,
           historyProvider: new HashHistory(windowImpl: mockWindow),
-          clickHandler: expectAsync((_) {}));
+          clickHandler: expectAsync((Event e) {
+        e.preventDefault();
+      }));
       router.listen(appRoot: root);
 
       // Trigger handle method in linkHandler
       anchor.dispatchEvent(new MouseEvent('click'));
-    }, skip: "TODO: expectAsync isn't working with this");
+    });
 
     test('should be called if event triggered on child of an anchor element',
         () {
@@ -128,11 +130,13 @@ main() {
       var router = new Router(
           useFragment: true,
           historyProvider: new HashHistory(windowImpl: mockWindow),
-          clickHandler: expectAsync((_) {}));
+          clickHandler: expectAsync((Event e) {
+        e.preventDefault();
+      }));
       router.listen(appRoot: root);
 
       // Trigger handle method in linkHandler
       anchorChild.dispatchEvent(new MouseEvent('click'));
-    }, skip: "TODO: expectAsync isn't working with this");
+    });
   });
 }

--- a/test/click_handler_test.dart
+++ b/test/click_handler_test.dart
@@ -1,7 +1,7 @@
 library route.click_handler_test;
 
 import 'dart:html';
-import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:route_hierarchical/click_handler.dart';
@@ -17,17 +17,10 @@ main() {
     MockRouter router;
     MockWindow mockWindow;
     Element root;
-    StreamController onHashChangeController;
 
     setUp(() {
       router = new MockRouter();
       mockWindow = new MockWindow();
-      // TODO - consider wrapping these when statements into the mocks themselves
-      // (if they are consistent across the test suites)
-      when(mockWindow.location.host).thenReturn(window.location.host);
-      when(mockWindow.location.hash).thenReturn('');
-      onHashChangeController = new StreamController();
-      when(mockWindow.onHashChange).thenReturn(onHashChangeController.stream);
       root = new DivElement();
       document.body.append(root);
       linkHandler = new DefaultWindowClickHandler(
@@ -42,20 +35,9 @@ main() {
       root.remove();
     });
 
-    MouseEvent _createMockMouseEvent({String anchorTarget, String anchorHref}) {
-      AnchorElement anchor = new AnchorElement();
-      if (anchorHref != null) anchor.href = anchorHref;
-      if (anchorTarget != null) anchor.target = anchorTarget;
-
-      MockMouseEvent mockMouseEvent = new MockMouseEvent();
-      when(mockMouseEvent.target).thenReturn(anchor);
-      when(mockMouseEvent.path).thenReturn([anchor]);
-      return mockMouseEvent;
-    }
-
     test('should process AnchorElements which have target set', () {
       MockMouseEvent mockMouseEvent =
-          _createMockMouseEvent(anchorHref: '#test');
+          new MockMouseEvent.withAnchor(href: '#test');
       linkHandler(mockMouseEvent);
       List calls = verify(router.gotoUrl(captureAny)).captured;
       expect(calls.length, 1);
@@ -66,19 +48,19 @@ main() {
         'should process AnchorElements which has target set to _blank, _self, _top or _parent',
         () {
       MockMouseEvent mockMouseEvent =
-          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_blank');
+          new MockMouseEvent.withAnchor(href: '#test', target: '_blank');
       linkHandler(mockMouseEvent);
 
       mockMouseEvent =
-          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_self');
+          new MockMouseEvent.withAnchor(href: '#test', target: '_self');
       linkHandler(mockMouseEvent);
 
       mockMouseEvent =
-          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_top');
+          new MockMouseEvent.withAnchor(href: '#test', target: '_top');
       linkHandler(mockMouseEvent);
 
       mockMouseEvent =
-          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_parent');
+          new MockMouseEvent.withAnchor(href: '#test', target: '_parent');
       linkHandler(mockMouseEvent);
 
       // We expect 0 calls to router.gotoUrl
@@ -92,9 +74,8 @@ main() {
       anchor.href = '#test';
       anchor.append(anchorChild);
 
-      MockMouseEvent mockMouseEvent = new MockMouseEvent();
-      when(mockMouseEvent.target).thenReturn(anchorChild);
-      when(mockMouseEvent.path).thenReturn([anchorChild, anchor]);
+      MockMouseEvent mockMouseEvent =
+          new MockMouseEvent(target: anchorChild, path: [anchorChild, anchor]);
 
       linkHandler(mockMouseEvent);
       List calls = verify(router.gotoUrl(captureAny)).captured;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -992,7 +992,6 @@ main() {
           useFragment: false,
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
       router.root.addRoute(name: 'articles', path: '/articles');
-      when(mockWindow.document.title).thenReturn('page title');
 
       router.go('articles', {}).then(expectAsync((_) {
         var mockHistory = mockWindow.history;
@@ -1023,7 +1022,6 @@ main() {
           useFragment: false,
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
       router.root.addRoute(name: 'articles', path: '/articles');
-      when(mockWindow.document.title).thenReturn('page title');
 
       var queryParams = {'foo': 'foo bar', 'bar': '%baz+aux'};
       router
@@ -1049,7 +1047,6 @@ main() {
 
     test('should work with hierarchical go', () {
       var mockWindow = new MockWindow();
-      when(mockWindow.document.title).thenReturn('page title');
       var router = new Router(
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
       router.root
@@ -1093,7 +1090,6 @@ main() {
       var counters = <String, int>{'aEnter': 0, 'bEnter': 0};
 
       var mockWindow = new MockWindow();
-      when(mockWindow.document.title).thenReturn('page title');
       var router = new Router(
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
       router.root
@@ -1131,7 +1127,6 @@ main() {
       var counters = <String, int>{'aEnter': 0, 'bEnter': 0};
 
       var mockWindow = new MockWindow();
-      when(mockWindow.document.title).thenReturn('page title');
       var router = new Router(
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
       router.root
@@ -1179,7 +1174,6 @@ main() {
 
     test('should not change page title if the title property is not set', () {
       var mockWindow = new MockWindow();
-      when(mockWindow.document.title).thenReturn('page title');
       var router = new Router(
           useFragment: false,
           historyProvider: new BrowserHistory(windowImpl: mockWindow));
@@ -1568,10 +1562,6 @@ main() {
     group('fragment', () {
       test('should route current hash on listen', () {
         var mockWindow = new MockWindow();
-        var mockHashChangeController = new StreamController<Event>(sync: true);
-
-        when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
         var router = new Router(
             useFragment: true,
@@ -1588,7 +1578,6 @@ main() {
 
     group('pushState', () {
       testInit(mockWindow, [count = 1]) {
-        when(mockWindow.location.hash).thenReturn('');
         when(mockWindow.location.pathname).thenReturn('/hello');
         when(mockWindow.location.search).thenReturn('?foo=bar&baz=bat');
         var router = new Router(
@@ -1637,12 +1626,7 @@ main() {
         document.body.append(toRemove = anchor);
 
         var mockWindow = new MockWindow();
-        var mockHashChangeController = new StreamController<Event>(sync: true);
-
-        when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
-        when(mockWindow.location.host).thenReturn(window.location.host);
 
         var router = new Router(
             useFragment: true,
@@ -1666,12 +1650,7 @@ main() {
         document.body.append(toRemove = anchor);
 
         var mockWindow = new MockWindow();
-        var mockHashChangeController = new StreamController<Event>(sync: true);
-
-        when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
-        when(mockWindow.location.host).thenReturn(window.location.host);
 
         var router = new Router(
             useFragment: true,

--- a/test/util/mocks.dart
+++ b/test/util/mocks.dart
@@ -4,7 +4,9 @@
 
 library route.test_mocks;
 
+import 'dart:async';
 import 'dart:html';
+
 import 'package:mockito/mockito.dart';
 import 'package:route_hierarchical/client.dart';
 
@@ -12,6 +14,17 @@ class MockWindow extends Mock implements Window {
   final history = new MockHistory();
   final location = new MockLocation();
   final document = new MockDocument();
+
+  StreamController _onHashChangeController;
+
+  MockWindow() {
+    when(location.host).thenReturn(window.location.host);
+    when(location.hash).thenReturn('');
+    when(document.title).thenReturn('page title');
+
+    _onHashChangeController = new StreamController();
+    when(this.onHashChange).thenReturn(_onHashChangeController.stream);
+  }
 }
 
 class MockHistory extends Mock implements History {}
@@ -20,6 +33,20 @@ class MockLocation extends Mock implements Location {}
 
 class MockDocument extends Mock implements HtmlDocument {}
 
-class MockMouseEvent extends Mock implements MouseEvent {}
+class MockMouseEvent extends Mock implements MouseEvent {
+  MockMouseEvent({EventTarget target, List<Node> path}) {
+    when(this.target).thenReturn(target);
+    when(this.path).thenReturn(path);
+  }
+
+  MockMouseEvent.withAnchor({String target: '', String href: ''}) {
+    AnchorElement anchor = new AnchorElement();
+    anchor.href = href;
+    anchor.target = target;
+
+    when(this.target).thenReturn(anchor);
+    when(this.path).thenReturn([anchor]);
+  }
+}
 
 class MockRouter extends Mock implements Router {}


### PR DESCRIPTION
## Issue
- 2 tests were skipped because they were failing for an, at the time, unknown async reason
- test mocks could be better consolidated
## Changes

**Source:**
- changes are confined to test files

**Tests:**
- unskip the 2 skipped tests by adding `e.preventDefault` in the mock click handler
- reorganize the mocks so they're consolidated
## Areas of Regression
- none
## Testing
- make sure tests pass smithy
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
