### PR TITLE
CP-1185 Release route.dart 0.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: route_hierarchical
-version: 0.7.0
+version: 0.8.0
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1185

JIRA and PR's included in this release: 

 CP-1210  - fix skipped async test failure  - https://github.com/Workiva/route.dart/pull/3
 CP-1219  - Enable TravisCI, route.dart  - https://github.com/Workiva/route.dart/pull/5
 CP-1217  - ALL THE TODOS, route.dart  - https://github.com/Workiva/route.dart/pull/4
 CP-1235  - Use first specified default route, but dont throw on multiples  - https://github.com/Workiva/route.dart/pull/6

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/route.dart/compare/0.7.0...CP-1185_release_0.8.0
