### PR TITLE
CP-1257 Fix page title setting for all routing cases

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -537,7 +537,14 @@ class Router {
     var treePath = _matchingTreePath(path, baseRoute);
     // Figure out the list of routes that will be leaved
     var future =
-        _preLeave(path, treePath, trimmedActivePath, baseRoute, forceReload);
+        _preLeave(path, treePath, trimmedActivePath, baseRoute, forceReload)
+            .then((success) {
+      // if the route change was successful, change the pageTitle
+      if ((success) && (treePath.isNotEmpty)) {
+        _history.pageTitle = treePath.last.route.pageTitle;
+      }
+      return success;
+    });
     _onRouteStart.add(new RouteStartEvent._new(path, future));
     return future;
   }
@@ -781,7 +788,7 @@ class Router {
     return route(newTail, startingFrom: baseRoute, forceReload: forceReload)
         .then((success) {
       if (success) {
-        _go(newUrl, routeToGo.pageTitle, replace);
+        _go(newUrl, replace);
       }
       return success;
     });
@@ -906,12 +913,13 @@ class Router {
    */
   Future<bool> gotoUrl(String url) => route(url).then((success) {
         if (success) {
-          _go(url, null, false);
+          _go(url, false);
         }
+        return success;
       });
 
-  void _go(String path, String title, bool replace) {
-    _history.go(path, title, replace);
+  void _go(String path, bool replace) {
+    _history.go(path, replace);
   }
 
   /**

--- a/lib/history_provider.dart
+++ b/lib/history_provider.dart
@@ -15,9 +15,10 @@ abstract class HistoryProvider {
   Stream get onChange;
   String get path;
   String get urlStub;
+  String pageTitle;
 
   void clickHandler(
       Event e, RouterLinkMatcher linkMatcher, Future<bool> gotoUrl(String url));
-  void go(String path, String title, bool replace);
+  void go(String path, bool replace);
   void back();
 }

--- a/lib/providers/browser_history.dart
+++ b/lib/providers/browser_history.dart
@@ -2,6 +2,7 @@ part of route.history_provider;
 
 class BrowserHistory implements HistoryProvider {
   Window _window;
+  String _pageTitle;
 
   BrowserHistory({Window windowImpl}) {
     _window = windowImpl ?? window;
@@ -13,6 +14,16 @@ class BrowserHistory implements HistoryProvider {
       '${_window.location.hash}';
 
   String get urlStub => '';
+
+  String get pageTitle =>
+      _pageTitle ?? (_window.document as HtmlDocument).title;
+
+  void set pageTitle(String title) {
+    if (title != null) {
+      _pageTitle = title;
+      (_window.document as HtmlDocument).title = _pageTitle;
+    }
+  }
 
   void clickHandler(Event e, RouterLinkMatcher linkMatcher,
       Future<bool> gotoUrl(String url)) {
@@ -33,16 +44,12 @@ class BrowserHistory implements HistoryProvider {
     }
   }
 
-  void go(String path, String title, bool replace) {
-    if (title == null) {
-      title = (_window.document as HtmlDocument).title;
-    }
+  void go(String path, bool replace) {
     if (replace) {
-      _window.history.replaceState(null, title, path);
+      _window.history.replaceState(null, pageTitle, path);
     } else {
-      _window.history.pushState(null, title, path);
+      _window.history.pushState(null, pageTitle, path);
     }
-    (_window.document as HtmlDocument).title = title;
   }
 
   void back() {

--- a/lib/providers/hash_history.dart
+++ b/lib/providers/hash_history.dart
@@ -2,6 +2,7 @@ part of route.history_provider;
 
 class HashHistory implements HistoryProvider {
   Window _window;
+  String _pageTitle;
 
   HashHistory({Window windowImpl}) {
     _window = windowImpl ?? window;
@@ -12,6 +13,16 @@ class HashHistory implements HistoryProvider {
   String get path => _normalizeHash(_window.location.hash);
 
   String get urlStub => '#';
+
+  String get pageTitle =>
+      _pageTitle ?? (_window.document as HtmlDocument).title;
+
+  void set pageTitle(String title) {
+    if (title != null) {
+      _pageTitle = title;
+      (_window.document as HtmlDocument).title = _pageTitle;
+    }
+  }
 
   void clickHandler(Event e, RouterLinkMatcher linkMatcher,
       Future<bool> gotoUrl(String url)) {
@@ -32,14 +43,11 @@ class HashHistory implements HistoryProvider {
     }
   }
 
-  void go(String path, String title, bool replace) {
+  void go(String path, bool replace) {
     if (replace) {
       _window.location.replace('#$path');
     } else {
       _window.location.assign('#$path');
-    }
-    if (title != null) {
-      (_window.document as HtmlDocument).title = title;
     }
   }
 

--- a/lib/providers/memory_history.dart
+++ b/lib/providers/memory_history.dart
@@ -23,6 +23,8 @@ class MemoryHistory implements HistoryProvider {
 
   String get urlStub => _namespace;
 
+  String pageTitle = '';
+
   void clickHandler(Event e, RouterLinkMatcher linkMatcher,
       Future<bool> gotoUrl(String url)) {
     Element el = e.target;
@@ -42,7 +44,7 @@ class MemoryHistory implements HistoryProvider {
     }
   }
 
-  void go(String path, String title, bool replace) {
+  void go(String path, bool replace) {
     if (replace) {
       _urlList.removeLast();
     }

--- a/test/providers/hash_history_test.dart
+++ b/test/providers/hash_history_test.dart
@@ -308,7 +308,18 @@ main() {
       });
 
       group('links', () {
+        MockWindow mockWindow;
+        HistoryProvider history;
+        Router router;
         Element toRemove;
+
+        setUp(() {
+          mockWindow = new MockWindow();
+          history = new HashHistory(windowImpl: mockWindow);
+          when(mockWindow.location.hash).thenReturn('#/foo');
+          router = new Router(historyProvider: history);
+          router.root.addRoute(name: 'foo', path: '/foo', pageTitle: 'Foo');
+        });
 
         tearDown(() {
           if (toRemove != null) {
@@ -317,46 +328,43 @@ main() {
           }
         });
 
-        test('it should be called if event triggered on anchor element', () {
+        test('it should be called if event triggered on anchor element',
+            () async {
           AnchorElement anchor = new AnchorElement();
-          anchor.href = '#test1';
+          anchor.href = '#foo';
           document.body.append(toRemove = anchor);
 
-          var mockWindow = new MockWindow();
-          when(mockWindow.location.hash).thenReturn('#/foo');
-
-          var router = new Router(
-              historyProvider: new HashHistory(windowImpl: mockWindow));
           router.listen(appRoot: anchor);
 
-          router.onRouteStart.listen(expectAsync((RouteStartEvent e) {
-            expect(e.uri, 'test1');
-          }, max: 2));
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
 
           anchor.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('Foo'));
+          expect(router.findRoute('foo').isActive, isTrue);
         });
 
         test(
             'it should be called if event triggered on child of an anchor element',
-            () {
+            () async {
           Element anchorChild = new DivElement();
           AnchorElement anchor = new AnchorElement();
-          anchor.href = '#test2';
+          anchor.href = '#foo';
           anchor.append(anchorChild);
           document.body.append(toRemove = anchor);
 
-          var mockWindow = new MockWindow();
-          when(mockWindow.location.hash).thenReturn('#/foo');
-
-          var router = new Router(
-              historyProvider: new HashHistory(windowImpl: mockWindow));
           router.listen(appRoot: anchor);
 
-          router.onRouteStart.listen(expectAsync((RouteStartEvent e) {
-            expect(e.uri, 'test2');
-          }, max: 2));
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
 
           anchorChild.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('Foo'));
+          expect(router.findRoute('foo').isActive, isTrue);
         });
       });
     });


### PR DESCRIPTION
## Issue
- A route can define a pageTitle to be used for the browser window / tab title whenever that route is entered, but that only worked when entering the route via the `go` API call
  - didn't work when using the `goToUrl` API method
  - didn't work when clicking on links (ultimately uses the `goToUrl` API method)
  - didn't work on initial page load
  - didn't work when changing the route by typing a new route in the browser url bar
## Changes

**Source:**
- shifted the pageTitle processing to occur in the existing `route` method, which is actually used in all of the above cases to execute a route change

**Tests:**
- existing tests covered the case that worked
- added tests for the link clicking changes
## Areas of Regression
- page title changes for the above mentioned route change cases
## Testing
- CI passes
- can open the example html page and verify that the browser tab name changes when executing the above described scenarios
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
