### PR TITLE
CP-1280 Expose goBack API method

### DIFF
--- a/example/basic/example.dart
+++ b/example/basic/example.dart
@@ -28,6 +28,9 @@ main() {
 
   querySelector('#R1linkOne').attributes['href'] = router.url('one');
   querySelector('#R1linkTwo').attributes['href'] = router.url('two');
+  querySelector('#R1linkBackButton').onClick.listen((e) {
+    router.goBack();
+  });
 
   router.listen();
 
@@ -47,6 +50,9 @@ main() {
 
   querySelector('#R2linkOne').attributes['href'] = router2.url('one');
   querySelector('#R2linkTwo').attributes['href'] = router2.url('two');
+  querySelector('#R2linkBackButton').onClick.listen((e) {
+    router2.goBack();
+  });
 
   router2.listen();
 }

--- a/example/basic/example.html
+++ b/example/basic/example.html
@@ -48,6 +48,7 @@
       <nav>
         <a href="#" id="R1linkOne" title="Section One">One</a>
         <a href="#" id="R1linkTwo" title="Section Two">Two</a>
+        <button id="R1linkBackButton">Back</button>
         <a href="http://www.google.com" title="Google">Google</a>
       </nav>
 
@@ -63,6 +64,7 @@
       <nav>
         <a href="#" id="R2linkOne" title="Section One">One</a>
         <a href="#" id="R2linkTwo" title="Section Two">Two</a>
+        <button id="R2linkBackButton">Back</button>
         <a href="http://www.google.com" title="Google">Google</a>
       </nav>
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -794,6 +794,11 @@ class Router {
     });
   }
 
+  /// Navigate to the previous url via the historyProvider's back mechanism
+  void goBack() {
+    _history.back();
+  }
+
   /// Returns an absolute URL for a given relative route path and parameters.
   String url(String routePath,
       {Route startingFrom, Map parameters, Map queryParameters}) {

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -149,6 +149,24 @@ main() {
       });
     });
 
+    group('goBack', () {
+      test('should go to the previous route', () async {
+        MockWindow mockWindow = new MockWindow();
+        Router router = new Router(
+            historyProvider: new BrowserHistory(windowImpl: mockWindow));
+
+        router.root.addRoute(name: 'foo', path: '/foo');
+        router.root.addRoute(name: 'bar', path: '/bar');
+
+        await router.go('foo', {});
+        await router.go('bar', {});
+        expect(mockWindow.history.urlList, equals(['/foo', '/bar']));
+
+        router.goBack();
+        expect(mockWindow.history.urlList, equals(['/foo']));
+      });
+    });
+
     group('url', () {
       test('should reconstruct url', () async {
         var mockWindow = new MockWindow();

--- a/test/providers/hash_history_test.dart
+++ b/test/providers/hash_history_test.dart
@@ -146,6 +146,24 @@ main() {
       });
     });
 
+    group('goBack', () {
+      test('should go to the previous route', () async {
+        MockWindow mockWindow = new MockWindow();
+        Router router = new Router(
+            historyProvider: new HashHistory(windowImpl: mockWindow));
+
+        router.root.addRoute(name: 'foo', path: '/foo');
+        router.root.addRoute(name: 'bar', path: '/bar');
+
+        await router.go('foo', {});
+        await router.go('bar', {});
+        expect(mockWindow.history.urlList, equals(['#/foo', '#/bar']));
+
+        router.goBack();
+        expect(mockWindow.history.urlList, equals(['#/foo']));
+      });
+    });
+
     group('url', () {
       test('should reconstruct url', () async {
         var mockWindow = new MockWindow();

--- a/test/providers/memory_history_test.dart
+++ b/test/providers/memory_history_test.dart
@@ -122,6 +122,24 @@ main() {
       });
     });
 
+    group('goBack', () {
+      test('should go to the previous route', () async {
+        List<String> urlHistory = [];
+        Router router = new Router(
+            historyProvider: new MemoryHistory(urlHistory: urlHistory));
+
+        router.root.addRoute(name: 'foo', path: '/foo');
+        router.root.addRoute(name: 'bar', path: '/bar');
+
+        await router.go('foo', {});
+        await router.go('bar', {});
+        expect(urlHistory, equals(['/foo', '/bar']));
+
+        router.goBack();
+        expect(urlHistory, equals(['/foo']));
+      });
+    });
+
     group('url', () {
       test('should reconstruct url', () async {
         var router = new Router(historyProvider: new MemoryHistory());


### PR DESCRIPTION
## Issue
- since we support multiple history providers that each have a `back` method, we should expose that through the router for easier consumption
## Changes

**Source:**
- piped historyProvider's `back` method to router's `goBack` method

**Tests:**
- added tests and example back buttons
## Areas of Regression
- none, this is new stuff
## Testing
- smithy is happy
- could click around on the example page and verify that back buttons work as expected
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
