### PR TITLE
CP-1284 add support for redirect routes

### DIFF
--- a/example/basic/example.dart
+++ b/example/basic/example.dart
@@ -25,7 +25,7 @@ main() {
         enter: showR1One)
     ..addRoute(
         name: 'two', path: '/two', pageTitle: 'Route Two', enter: showR1Two)
-    ..addRedirect(name: 'two', path: '/redirect');
+    ..addRedirect(path: '/redirect', toRoute: 'two');
 
   querySelector('#R1linkOne').attributes['href'] = router.url('one');
   querySelector('#R1linkTwo').attributes['href'] = router.url('two');
@@ -51,7 +51,7 @@ main() {
         path: '/two',
         pageTitle: 'Route Two',
         enter: showR2Two)
-    ..addRedirect(name: 'two', path: '/redirect');
+    ..addRedirect(path: '/redirect', toRoute: 'two');
 
   querySelector('#R2linkOne').attributes['href'] = router2.url('one');
   querySelector('#R2linkTwo').attributes['href'] = router2.url('two');

--- a/example/basic/example.dart
+++ b/example/basic/example.dart
@@ -24,10 +24,14 @@ main() {
         pageTitle: 'Route One',
         enter: showR1One)
     ..addRoute(
-        name: 'two', path: '/two', pageTitle: 'Route Two', enter: showR1Two);
+        name: 'two', path: '/two', pageTitle: 'Route Two', enter: showR1Two)
+    ..addRedirect(name: 'two', path: '/redirect');
 
   querySelector('#R1linkOne').attributes['href'] = router.url('one');
   querySelector('#R1linkTwo').attributes['href'] = router.url('two');
+  querySelector('#R1redirectButton').onClick.listen((e) async {
+    router.gotoUrl('/redirect');
+  });
   querySelector('#R1linkBackButton').onClick.listen((e) {
     router.goBack();
   });
@@ -46,10 +50,14 @@ main() {
         defaultRoute: true,
         path: '/two',
         pageTitle: 'Route Two',
-        enter: showR2Two);
+        enter: showR2Two)
+    ..addRedirect(name: 'two', path: '/redirect');
 
   querySelector('#R2linkOne').attributes['href'] = router2.url('one');
   querySelector('#R2linkTwo').attributes['href'] = router2.url('two');
+  querySelector('#R2redirectButton').onClick.listen((e) {
+    router2.gotoUrl('/redirect');
+  });
   querySelector('#R2linkBackButton').onClick.listen((e) {
     router2.goBack();
   });

--- a/example/basic/example.dart
+++ b/example/basic/example.dart
@@ -29,7 +29,7 @@ main() {
 
   querySelector('#R1linkOne').attributes['href'] = router.url('one');
   querySelector('#R1linkTwo').attributes['href'] = router.url('two');
-  querySelector('#R1redirectButton').onClick.listen((e) async {
+  querySelector('#R1redirectButton').onClick.listen((e) {
     router.gotoUrl('/redirect');
   });
   querySelector('#R1linkBackButton').onClick.listen((e) {

--- a/example/basic/example.html
+++ b/example/basic/example.html
@@ -48,6 +48,7 @@
       <nav>
         <a href="#" id="R1linkOne" title="Section One">One</a>
         <a href="#" id="R1linkTwo" title="Section Two">Two</a>
+        <button id="R1redirectButton">Redirect</button>
         <button id="R1linkBackButton">Back</button>
         <a href="http://www.google.com" title="Google">Google</a>
       </nav>
@@ -64,6 +65,7 @@
       <nav>
         <a href="#" id="R2linkOne" title="Section One">One</a>
         <a href="#" id="R2linkTwo" title="Section Two">Two</a>
+        <button id="R2redirectButton">Redirect</button>
         <button id="R2linkBackButton">Back</button>
         <a href="http://www.google.com" title="Google">Google</a>
       </nav>

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -135,7 +135,7 @@ abstract class Route {
       String pageTitle,
       List<Pattern> watchQueryParameters});
 
-  void addRedirect({String name, Pattern path});
+  void addRedirect({Pattern path, String toRoute});
 
   /**
    * Queries sub-routes using the [routePath] and returns the matching [Route].
@@ -279,14 +279,14 @@ class RouteImpl extends Route {
   }
 
   @override
-  void addRedirect({String name, Pattern path}) {
+  void addRedirect({Pattern path, String toRoute}) {
     // use the specified path matcher to route to an existing named path
-    if (_routes[name] == null) {
+    if (_routes[toRoute] == null) {
       throw new ArgumentError('redirect must specify an existing route name');
     }
 
     var matcher = path is UrlMatcher ? path : new UrlTemplate(path.toString());
-    _routes[name].redirects.add(matcher);
+    _routes[toRoute].redirects.add(matcher);
   }
 
   @override

--- a/lib/route_handle.dart
+++ b/lib/route_handle.dart
@@ -79,7 +79,7 @@ class RouteHandle implements Route {
 
   /// Not supported. Overridden to throw an error.
   @override
-  void addRedirect({String name, Pattern path}) {
+  void addRedirect({Pattern path, String toRoute}) {
     throw new UnsupportedError('addRedirect is not supported in handle');
   }
 

--- a/lib/route_handle.dart
+++ b/lib/route_handle.dart
@@ -77,6 +77,12 @@ class RouteHandle implements Route {
     throw new UnsupportedError('addRoute is not supported in handle');
   }
 
+  /// Not supported. Overridden to throw an error.
+  @override
+  void addRedirect({String name, Pattern path}) {
+    throw new UnsupportedError('addRedirect is not supported in handle');
+  }
+
   @override
   Route findRoute(String routePath) {
     Route r = _assertState(() => _getHost(_route).findRoute(routePath));

--- a/lib/route_view.dart
+++ b/lib/route_view.dart
@@ -93,6 +93,12 @@ class RouteView implements Route {
 
   /// Not supported. Overridden to throw an error.
   @override
+  void addRedirect({String name, Pattern path}) {
+    throw new UnsupportedError('addRedirect is not supported by RouteView');
+  }
+
+  /// Not supported. Overridden to throw an error.
+  @override
   Route findRoute(String routePath) {
     throw new UnsupportedError('findRoute is not supported by RouteView');
   }

--- a/lib/route_view.dart
+++ b/lib/route_view.dart
@@ -93,7 +93,7 @@ class RouteView implements Route {
 
   /// Not supported. Overridden to throw an error.
   @override
-  void addRedirect({String name, Pattern path}) {
+  void addRedirect({Pattern path, String toRoute}) {
     throw new UnsupportedError('addRedirect is not supported by RouteView');
   }
 

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -412,7 +412,7 @@ main() {
         });
 
         test('should correctly resolve redirect routes', () async {
-          router.root.addRedirect(name: 'foo', path: '/bar');
+          router.root.addRedirect(path: '/bar', toRoute: 'foo');
 
           AnchorElement anchor = new AnchorElement();
           anchor.href = '/bar';

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -19,12 +19,13 @@ main() {
 
     group('go', () {
       MockWindow mockWindow;
+      BrowserHistory historyProvider;
       Router router;
 
       setUp(() {
         mockWindow = new MockWindow();
-        router = new Router(
-            historyProvider: new BrowserHistory(windowImpl: mockWindow));
+        historyProvider = new BrowserHistory(windowImpl: mockWindow);
+        router = new Router(historyProvider: historyProvider);
       });
 
       test('should use history.push/.replaceState when using BrowserHistory',
@@ -404,6 +405,25 @@ main() {
           expect(router.findRoute('foo').isActive, isFalse);
 
           anchorChild.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('Foo'));
+          expect(router.findRoute('foo').isActive, isTrue);
+        });
+
+        test('should correctly resolve redirect routes', () async {
+          router.root.addRedirect(name: 'foo', path: '/bar');
+
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = '/bar';
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
 
           await new Future.delayed(Duration.ZERO);
           expect(history.pageTitle, equals('Foo'));

--- a/test/providers/common_tests.dart
+++ b/test/providers/common_tests.dart
@@ -220,16 +220,15 @@ commonProviderTests(RouterFactory routerFactory) {
   });
 
   group('redirects', () {
-    test('addRedirect should throw if a matching route name doesn\'t exist',
-        () {
-      expect(() => router.root.addRedirect(name: 'baz', path: '/baz'),
+    test('addRedirect should throw if a matching route doesn\'t exist', () {
+      expect(() => router.root.addRedirect(path: '/baz', toRoute: 'baz'),
           throwsArgumentError);
     });
 
     test('should route a redirect path to a valid route path', () async {
       router.root
         ..addRoute(name: 'foo', path: '/foo')
-        ..addRedirect(name: 'foo', path: '/bar');
+        ..addRedirect(path: '/bar', toRoute: 'foo');
 
       await router.route('/bar');
       expect(router.activeUrl, '/foo');
@@ -240,7 +239,7 @@ commonProviderTests(RouterFactory routerFactory) {
     test('should preserve route params', () async {
       router.root
         ..addRoute(name: 'foo', path: '/foo/:whatever')
-        ..addRedirect(name: 'foo', path: '/bar/:whatever');
+        ..addRedirect(path: '/bar/:whatever', toRoute: 'foo');
 
       await router.route('/bar/something');
       expect(router.activeUrl, '/foo/something');
@@ -251,7 +250,7 @@ commonProviderTests(RouterFactory routerFactory) {
     test('should preserve route query params', () async {
       router.root
         ..addRoute(name: 'foo', path: '/foo/:whatever')
-        ..addRedirect(name: 'foo', path: '/bar/:whatever');
+        ..addRedirect(path: '/bar/:whatever', toRoute: 'foo');
 
       await router.route('/bar/something?what=ever');
       expect(router.activeUrl, '/foo/something?what=ever');

--- a/test/providers/common_tests.dart
+++ b/test/providers/common_tests.dart
@@ -219,6 +219,47 @@ commonProviderTests(RouterFactory routerFactory) {
     });
   });
 
+  group('redirects', () {
+    test('addRedirect should throw if a matching route name doesn\'t exist',
+        () {
+      expect(() => router.root.addRedirect(name: 'baz', path: '/baz'),
+          throwsArgumentError);
+    });
+
+    test('should route a redirect path to a valid route path', () async {
+      router.root
+        ..addRoute(name: 'foo', path: '/foo')
+        ..addRedirect(name: 'foo', path: '/bar');
+
+      await router.route('/bar');
+      expect(router.activeUrl, '/foo');
+      expect(router.root.findRoute('foo').isActive, isTrue);
+      expect(router.isUrlActive('/foo'), isTrue);
+    });
+
+    test('should preserve route params', () async {
+      router.root
+        ..addRoute(name: 'foo', path: '/foo/:whatever')
+        ..addRedirect(name: 'foo', path: '/bar/:whatever');
+
+      await router.route('/bar/something');
+      expect(router.activeUrl, '/foo/something');
+      expect(router.root.findRoute('foo').isActive, isTrue);
+      expect(router.isUrlActive('/foo'), isTrue);
+    });
+
+    test('should preserve route query params', () async {
+      router.root
+        ..addRoute(name: 'foo', path: '/foo/:whatever')
+        ..addRedirect(name: 'foo', path: '/bar/:whatever');
+
+      await router.route('/bar/something?what=ever');
+      expect(router.activeUrl, '/foo/something?what=ever');
+      expect(router.root.findRoute('foo').isActive, isTrue);
+      expect(router.isUrlActive('/foo'), isTrue);
+    });
+  });
+
   group('hierarchical routing', () {
     void _testParentChild(Pattern parentPath, Pattern childPath,
         String expectedParentPath, String expectedChildPath, String testPath) {

--- a/test/providers/hash_history_test.dart
+++ b/test/providers/hash_history_test.dart
@@ -336,7 +336,6 @@ main() {
         setUp(() {
           mockWindow = new MockWindow();
           history = new HashHistory(windowImpl: mockWindow);
-          when(mockWindow.location.hash).thenReturn('#/foo');
           router = new Router(historyProvider: history);
           router.root.addRoute(name: 'foo', path: '/foo', pageTitle: 'Foo');
         });
@@ -351,7 +350,7 @@ main() {
         test('it should be called if event triggered on anchor element',
             () async {
           AnchorElement anchor = new AnchorElement();
-          anchor.href = '#foo';
+          anchor.href = '#/foo';
           document.body.append(toRemove = anchor);
 
           router.listen(appRoot: anchor);
@@ -371,7 +370,7 @@ main() {
             () async {
           Element anchorChild = new DivElement();
           AnchorElement anchor = new AnchorElement();
-          anchor.href = '#foo';
+          anchor.href = '#/foo';
           anchor.append(anchorChild);
           document.body.append(toRemove = anchor);
 
@@ -381,6 +380,25 @@ main() {
           expect(router.findRoute('foo').isActive, isFalse);
 
           anchorChild.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('Foo'));
+          expect(router.findRoute('foo').isActive, isTrue);
+        });
+
+        test('should correctly resolve redirect routes', () async {
+          router.root.addRedirect(name: 'foo', path: '/bar');
+
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = '#/bar';
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
 
           await new Future.delayed(Duration.ZERO);
           expect(history.pageTitle, equals('Foo'));

--- a/test/providers/hash_history_test.dart
+++ b/test/providers/hash_history_test.dart
@@ -387,7 +387,7 @@ main() {
         });
 
         test('should correctly resolve redirect routes', () async {
-          router.root.addRedirect(name: 'foo', path: '/bar');
+          router.root.addRedirect(path: '/bar', toRoute: 'foo');
 
           AnchorElement anchor = new AnchorElement();
           anchor.href = '#/bar';

--- a/test/providers/memory_history_test.dart
+++ b/test/providers/memory_history_test.dart
@@ -313,6 +313,25 @@ main() {
           expect(history.pageTitle, equals('Foo'));
           expect(router.findRoute('foo').isActive, isTrue);
         });
+
+        test('should correctly resolve redirect routes', () async {
+          router.root.addRedirect(name: 'foo', path: '/bar');
+
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = router.normalizeUrl('/bar');
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals(''));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('Foo'));
+          expect(router.findRoute('foo').isActive, isTrue);
+        });
       });
     });
 

--- a/test/providers/memory_history_test.dart
+++ b/test/providers/memory_history_test.dart
@@ -315,7 +315,7 @@ main() {
         });
 
         test('should correctly resolve redirect routes', () async {
-          router.root.addRedirect(name: 'foo', path: '/bar');
+          router.root.addRedirect(path: '/bar', toRoute: 'foo');
 
           AnchorElement anchor = new AnchorElement();
           anchor.href = router.normalizeUrl('/bar');

--- a/test/route_handle_test.dart
+++ b/test/route_handle_test.dart
@@ -125,6 +125,11 @@ main() {
             throwsUnsupportedError);
       });
 
+      test('should throw if adding a redirect', () {
+        expect(() => routeHandle.addRedirect(name: 'baz', path: '/baz'),
+            throwsUnsupportedError);
+      });
+
       test('should throw if RouteHandle has already been discarded', () {
         routeHandle.discard();
         expect(() => routeHandle.newHandle(), throwsStateError);

--- a/test/route_handle_test.dart
+++ b/test/route_handle_test.dart
@@ -126,7 +126,7 @@ main() {
       });
 
       test('should throw if adding a redirect', () {
-        expect(() => routeHandle.addRedirect(name: 'baz', path: '/baz'),
+        expect(() => routeHandle.addRedirect(path: '/baz', toRoute: 'baz'),
             throwsUnsupportedError);
       });
 

--- a/test/route_view_test.dart
+++ b/test/route_view_test.dart
@@ -93,6 +93,11 @@ main() {
             throwsUnsupportedError);
       });
 
+      test('should throw if adding a redirect', () {
+        expect(() => routeView.addRedirect(name: 'baz', path: '/baz'),
+            throwsUnsupportedError);
+      });
+
       test('should throw if finding a route', () {
         expect(() => routeView.findRoute('baz'), throwsUnsupportedError);
       });

--- a/test/route_view_test.dart
+++ b/test/route_view_test.dart
@@ -94,7 +94,7 @@ main() {
       });
 
       test('should throw if adding a redirect', () {
-        expect(() => routeView.addRedirect(name: 'baz', path: '/baz'),
+        expect(() => routeView.addRedirect(path: '/baz', toRoute: 'baz'),
             throwsUnsupportedError);
       });
 


### PR DESCRIPTION
## Issue
- need support for redirect routes

```
// setup
router.root
   ..addRoute(name: 'foo', path: '/foo/:whatever')
   ..addRedirect(path: '/bar/:whatever', toRoute: 'foo');

// both '#/foo/something' and '#/bar/something' activate the 'foo' route
// and display the '#/foo/something' path in the browser address bar
```
## Changes

**Source:**
- added support for redirect routes that covers all the routing consumption cases
  - link with href to redirect path
  - gotoUrl method usage
  - typed redirect path in browser address bar

**Tests:**
- added tests for route redirect functionality
  - raw route redirects
  - redirects with variable params
  - redirects with query params
## Areas of Regression
- new functionality only
## Testing
- smithy is happy
- can use example page to verify that the `#/redirect` route redirects to the existing `#/two` route
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
