### PR TITLE
CP-1275 Release route.dart 0.9.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: route_hierarchical
-version: 0.8.1
+version: 0.9.0
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1275

JIRA and PR's included in this release: 

 CP-1280  - Expose goBack API method  - https://github.com/Workiva/route.dart/pull/13

 CP-1284  - add support for redirect routes  - https://github.com/Workiva/route.dart/pull/14

 CP-1288  - Support dynamic page titles  - https://github.com/Workiva/route.dart/pull/15

 CP-1352  - Support dynamic / deferred route loading  - https://github.com/Workiva/route.dart/pull/16

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/route.dart/compare/0.8.1...CP-1275_release_0.9.0
