### PR TITLE
CP-1644 Prevent Router from capturing external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 packages
 pubspec.lock
+.packages
+.pub/
 .buildlog
 build/
 /node_modules/

--- a/lib/providers/browser_history.dart
+++ b/lib/providers/browser_history.dart
@@ -38,6 +38,10 @@ class BrowserHistory implements HistoryProvider {
     if (!linkMatcher.matches(anchor)) {
       return;
     }
+    if (anchor.target != null && anchor.target.isNotEmpty) {
+      // Prevent router from swallowing links that should open in another window
+      return;
+    }
     if (anchor.host == _window.location.host) {
       e.preventDefault();
       gotoUrl('${anchor.pathname}${anchor.search}');

--- a/lib/providers/hash_history.dart
+++ b/lib/providers/hash_history.dart
@@ -37,6 +37,10 @@ class HashHistory implements HistoryProvider {
     if (!linkMatcher.matches(anchor)) {
       return;
     }
+    if (anchor.target != null && anchor.target.isNotEmpty) {
+      // Prevent router from swallowing links that should open in another window
+      return;
+    }
     if (anchor.host == _window.location.host) {
       e.preventDefault();
       gotoUrl(_normalizeHash(anchor.hash));

--- a/lib/providers/memory_history.dart
+++ b/lib/providers/memory_history.dart
@@ -46,6 +46,10 @@ class MemoryHistory implements HistoryProvider {
     if (!linkMatcher.matches(anchor)) {
       return;
     }
+    if (anchor.target != null && anchor.target.isNotEmpty) {
+      // Prevent router from swallowing links that should open in another window
+      return;
+    }
     if (anchor.origin.startsWith(urlStub)) {
       e.preventDefault();
       gotoUrl(anchor.pathname);

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -402,6 +402,25 @@ main() {
           expect(router.findRoute('foo').isActive, isTrue);
         });
 
+        test('it should not be called if anchor element has a target attribute',
+            () async {
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = '/foo';
+          anchor.target = '_blank';
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+        });
+
         test(
             'it should be called if event triggered on child of an anchor element',
             () async {

--- a/test/providers/hash_history_test.dart
+++ b/test/providers/hash_history_test.dart
@@ -376,6 +376,25 @@ main() {
           expect(router.findRoute('foo').isActive, isTrue);
         });
 
+        test('it should not be called if anchor element has a target attribute',
+            () async {
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = '#/foo';
+          anchor.target = '_blank';
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals('page title'));
+          expect(router.findRoute('foo').isActive, isFalse);
+        });
+
         test(
             'it should be called if event triggered on child of an anchor element',
             () async {

--- a/test/providers/memory_history_test.dart
+++ b/test/providers/memory_history_test.dart
@@ -318,6 +318,25 @@ main() {
           expect(router.findRoute('foo').isActive, isTrue);
         });
 
+        test('it should not be called if anchor element has a target attribute',
+            () async {
+          AnchorElement anchor = new AnchorElement();
+          anchor.href = '/foo';
+          anchor.target = '_blank';
+          document.body.append(toRemove = anchor);
+
+          router.listen(appRoot: anchor);
+
+          expect(history.pageTitle, equals(''));
+          expect(router.findRoute('foo').isActive, isFalse);
+
+          anchor.click();
+
+          await new Future.delayed(Duration.ZERO);
+          expect(history.pageTitle, equals(''));
+          expect(router.findRoute('foo').isActive, isFalse);
+        });
+
         test(
             'it should be called if event triggered on child of an anchor element',
             () async {


### PR DESCRIPTION
## Issue

The router will currently ignore (not capture) any anchor that has an href to a different host. However, if the hosts match there is no way for it to be treated as an external link even if it is.
## Changes

**Source:**
- Do not handle the click if the Anchor element has a `target` attribute.

**Tests:**
- Added tests to ensure the route isn't switched when an anchor with a target is clicked.
## Testing
- CI passes (new unit tests cover new if conditions)
- Examples function
## Code Review

@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf
