### PR TITLE
CP-1714 Support replace option on gotoUrl method

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -971,10 +971,10 @@ class Router {
    * On older browsers [Location.assign] is used instead with the fragment
    * version of the UrlTemplate.
    */
-  Future<bool> gotoUrl(String url) {
+  Future<bool> gotoUrl(String url, {bool replace: false}) {
     return route(url).then((success) {
       if (success) {
-        _go(activeUrl, false);
+        _go(activeUrl, replace);
       }
       return success;
     });

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -162,6 +162,104 @@ main() {
       });
     });
 
+    group('gotoUrl', () {
+      MockWindow mockWindow;
+      BrowserHistory historyProvider;
+      Router router;
+
+      setUp(() {
+        mockWindow = new MockWindow();
+        historyProvider = new BrowserHistory(windowImpl: mockWindow);
+        router = new Router(historyProvider: historyProvider);
+      });
+
+      test('should use history.push/.replaceState when using BrowserHistory',
+          () async {
+        router.root.addRoute(name: 'articles', path: '/articles');
+
+        await router.gotoUrl('/articles');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/articles'));
+
+        await router.gotoUrl('/articles', replace: true);
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/articles'));
+      });
+
+      test('should support parameters in the URL', () async {
+        router.root.addRoute(name: 'foo', path: '/foo/:param');
+        await router.gotoUrl('/foo/something');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/foo/something'));
+        expect(router.activePath.last.parameters, {'param': 'something'});
+      });
+
+      test('should support query parameters in the URL', () async {
+        router.root.addRoute(name: 'articles', path: '/articles');
+        await router.gotoUrl('/articles?foo=foo%20bar&bar=%25baz%2Baux');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last,
+            equals('/articles?foo=foo%20bar&bar=%25baz%2Baux'));
+        expect(router.activePath.last.queryParameters,
+            {'foo': 'foo bar', 'bar': '%baz+aux'});
+      });
+
+      test('should work with hierarchical routes', () async {
+        router.root
+          ..addRoute(
+              name: 'a',
+              path: '/:foo',
+              mount: (child) => child..addRoute(name: 'b', path: '/:bar'));
+
+        Route routeA = router.root.findRoute('a');
+        Route routeB = router.root.findRoute('a.b');
+
+        await router.gotoUrl('/aaaa');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/aaaa'));
+        expect(routeA.isActive, true);
+        expect(routeA.parameters, {'foo': 'aaaa'});
+        expect(routeB.isActive, false);
+        expect(routeB.parameters, isNull);
+
+        await router.gotoUrl('/aaaa/bbbb');
+        expect(mockWindow.history.urlList.length, equals(2));
+        expect(mockWindow.history.urlList.last, equals('/aaaa/bbbb'));
+        expect(routeA.parameters, {'foo': 'aaaa'});
+        expect(routeB.parameters, {'bar': 'bbbb'});
+      });
+
+      test('should update page title if the title property is set', () async {
+        router.root.addRoute(name: 'foo', path: '/foo', pageTitle: 'Foo');
+
+        await router.gotoUrl('/foo');
+        verify(mockWindow.document.title = 'Foo');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/foo'));
+      });
+
+      test('should not change page title if the title property is not set',
+          () async {
+        router.root.addRoute(name: 'foo', path: '/foo');
+
+        await router.gotoUrl('/foo');
+        verifyNever(mockWindow.document.title = 'Foo');
+        expect(mockWindow.history.urlList.length, equals(1));
+        expect(mockWindow.history.urlList.last, equals('/foo'));
+      });
+
+      test('should support dynamic pageTitle based on route properties',
+          () async {
+        router.root.addRoute(
+            name: 'foo',
+            path: '/foo/:param',
+            pageTitle: (Route route) =>
+                'Foo: ${route.parameters['param']} - ${route.queryParameters['what']}');
+        await router.gotoUrl('/foo/something?what=ever');
+        expect(historyProvider.pageTitle, 'Foo: something - ever');
+      });
+    });
+
     group('goBack', () {
       test('should go to the previous route', () async {
         MockWindow mockWindow = new MockWindow();

--- a/test/providers/memory_history_test.dart
+++ b/test/providers/memory_history_test.dart
@@ -147,6 +147,97 @@ main() {
       });
     });
 
+    group('gotoUrl', () {
+      List<String> urlHistory;
+      MemoryHistory historyProvider;
+      Router router;
+
+      setUp(() {
+        urlHistory = [''];
+        historyProvider = new MemoryHistory(urlHistory: urlHistory);
+        router = new Router(historyProvider: historyProvider);
+      });
+
+      test('should use history.push/.replaceState when using BrowserHistory',
+          () async {
+        router.root.addRoute(name: 'articles', path: '/articles');
+
+        expect(urlHistory, equals(['']));
+        await router.gotoUrl('/articles');
+        expect(urlHistory, equals(['', '/articles']));
+
+        await router.gotoUrl('/articles', replace: true);
+        expect(urlHistory, equals(['', '/articles']));
+      });
+
+      test('should support parameters in the URL', () async {
+        router.root.addRoute(name: 'foo', path: '/foo/:param');
+        await router.gotoUrl('/foo/something');
+        expect(urlHistory, equals(['', '/foo/something']));
+        expect(router.activePath.last.parameters, {'param': 'something'});
+      });
+
+      test('should support query parameters in the URL', () async {
+        router.root.addRoute(name: 'articles', path: '/articles');
+        await router.gotoUrl('/articles?foo=foo%20bar&bar=%25baz%2Baux');
+        expect(urlHistory,
+            equals(['', '/articles?foo=foo%20bar&bar=%25baz%2Baux']));
+        expect(router.activePath.last.queryParameters,
+            {'foo': 'foo bar', 'bar': '%baz+aux'});
+      });
+
+      test('should work with hierarchical routes', () async {
+        router.root
+          ..addRoute(
+              name: 'a',
+              path: '/:foo',
+              mount: (child) => child..addRoute(name: 'b', path: '/:bar'));
+
+        Route routeA = router.root.findRoute('a');
+        Route routeB = router.root.findRoute('a.b');
+
+        await router.gotoUrl('/aaaa');
+        expect(urlHistory, equals(['', '/aaaa']));
+        expect(routeA.isActive, true);
+        expect(routeA.parameters, {'foo': 'aaaa'});
+        expect(routeB.isActive, false);
+        expect(routeB.parameters, isNull);
+
+        await router.gotoUrl('/aaaa/bbbb');
+        expect(urlHistory, equals(['', '/aaaa', '/aaaa/bbbb']));
+        expect(routeA.parameters, {'foo': 'aaaa'});
+        expect(routeB.parameters, {'bar': 'bbbb'});
+      });
+
+      test('should update page title if the title property is set', () async {
+        router.root.addRoute(name: 'foo', path: '/foo', pageTitle: 'Foo');
+
+        await router.gotoUrl('/foo');
+        expect(historyProvider.pageTitle, 'Foo');
+        expect(urlHistory, equals(['', '/foo']));
+      });
+
+      test('should not change page title if the title property is not set',
+          () async {
+        router.root.addRoute(name: 'foo', path: '/foo');
+
+        await router.gotoUrl('/foo');
+        expect(historyProvider.pageTitle, '');
+        expect(urlHistory, equals(['', '/foo']));
+      });
+
+      test('should support dynamic pageTitle based on route properties',
+          () async {
+        router.root.addRoute(
+            name: 'foo',
+            path: '/foo/:param',
+            pageTitle: (Route route) =>
+                'Foo: ${route.parameters['param']} - ${route.queryParameters['what']}');
+        await router.gotoUrl('/foo/something?what=ever');
+        expect(historyProvider.pageTitle, 'Foo: something - ever');
+      });
+    });
+
     group('goBack', () {
       test('should go to the previous route', () async {
         List<String> urlHistory = [];

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -9,10 +9,8 @@ main() {
     test('toString should return stringified url pattern', () {
       var tmpl = new UrlTemplate('/foo/bar:baz/aux');
       expect(tmpl.urlParameterNames, equals(['baz']));
-      expect(
-          tmpl.toString(),
-          equals(
-              'UrlTemplate(JSRegExp: pattern=^/foo/bar([^/?]+)/aux flags=)'));
+      expect(tmpl.toString(),
+          equals('UrlTemplate(RegExp: pattern=^/foo/bar([^/?]+)/aux flags=)'));
     });
 
     test('should work with simple templates', () {

--- a/test/util/mocks.dart
+++ b/test/util/mocks.dart
@@ -54,12 +54,12 @@ class MockHistory extends Mock implements History {
     urlList.removeLast();
   }
 
-  replaceState(Object data, String title, [String url]) {
+  replaceState(Object data, String title, String url, [Map options]) {
     urlList.removeLast();
     urlList.add(url);
   }
 
-  pushState(Object data, String title, [String url]) {
+  pushState(Object data, String title, String url, [Map options]) {
     urlList.add(url);
   }
 }


### PR DESCRIPTION
## Issue
- the `go` method supports an optional `replace` option, so `gotoUrl` should too (it's useful)
  - when used, `replace` will perform the route change and replace the current window.history entry with the resulting location, instead of adding a new history entry
## Changes

**Source:**
- added the optional param

**Tests:**
- added missing tests (mostly copy paste from the `go` method with relevant tweaks)
## Areas of Regression
- none
## Testing
- smithy passes - will have a real use for this in w_router / wdesk shortly...
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
