### PR TITLE
CP-2673 Handle initial route being rejected by preEnter

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -951,7 +951,12 @@ class Router {
         });
       }
     });
-    route(_history.path);
+    route(_history.path).then((allowed) {
+      if (!allowed) {
+        _logger.fine('Initial route not allowed: ${_history.path}');
+        route('');
+      }
+    });
 
     if (!ignoreClick) {
       if (appRoot == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   logging: any
   uuid: "^0.5.0"
 dev_dependencies:
+  analyzer: "^0.27.3"
   browser: any
   mockito: "^0.10.0"
   coverage: "^0.7.2"

--- a/test/providers/browser_history_test.dart
+++ b/test/providers/browser_history_test.dart
@@ -461,7 +461,9 @@ main() {
 
         test('should handle route rejection on initial URL', () async {
           var mockWindow = new MockWindow();
-          when(mockWindow.path).thenReturn('/foo');
+          when(mockWindow.location.pathname).thenReturn('/foo');
+          when(mockWindow.location.search).thenReturn('');
+          when(mockWindow.location.hash).thenReturn('');
           var router = new Router(
               historyProvider: new BrowserHistory(windowImpl: mockWindow));
           var fallbackCompleter = new Completer();
@@ -471,7 +473,6 @@ main() {
                 path: '/fallback',
                 defaultRoute: true,
                 enter: (RouteEnterEvent e) {
-                  print('Fallback!');
                   if (!fallbackCompleter.isCompleted) {
                     fallbackCompleter.complete();
                   }

--- a/test/providers/common_tests.dart
+++ b/test/providers/common_tests.dart
@@ -443,7 +443,12 @@ commonProviderTests(RouterFactory routerFactory) {
     Map counters;
 
     setUp(() {
-      counters = {'fooLeave': 0, 'fooEnter': 0, 'barLeave': 0, 'barEnter': 0,};
+      counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+        'barLeave': 0,
+        'barEnter': 0,
+      };
 
       router.root
         ..addRoute(
@@ -466,32 +471,56 @@ commonProviderTests(RouterFactory routerFactory) {
 
     test('should reload currently active route', () async {
       await router.route('/123');
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 0, 'barEnter': 0,});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 0,
+        'barEnter': 0,
+      });
       await router.reload();
-      expect(counters,
-          {'fooLeave': 1, 'fooEnter': 2, 'barLeave': 0, 'barEnter': 0,});
+      expect(counters, {
+        'fooLeave': 1,
+        'fooEnter': 2,
+        'barLeave': 0,
+        'barEnter': 0,
+      });
       expect(router.findRoute('foo').parameters['foo'], '123');
     });
 
     test('should reload currently active route from startingFrom', () async {
       await router.route('/123/321');
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 0, 'barEnter': 1,});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 0,
+        'barEnter': 1,
+      });
       await router.reload(startingFrom: router.findRoute('foo'));
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 1, 'barEnter': 2,});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 1,
+        'barEnter': 2,
+      });
       expect(router.findRoute('foo').parameters['foo'], '123');
       expect(router.findRoute('foo.bar').parameters['bar'], '321');
     });
 
     test('should preserve param values on reload', () async {
       await router.route('/123/321');
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 0, 'barEnter': 1,});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 0,
+        'barEnter': 1,
+      });
       await router.reload();
-      expect(counters,
-          {'fooLeave': 1, 'fooEnter': 2, 'barLeave': 1, 'barEnter': 2,});
+      expect(counters, {
+        'fooLeave': 1,
+        'fooEnter': 2,
+        'barLeave': 1,
+        'barEnter': 2,
+      });
       expect(router.findRoute('foo').parameters['foo'], '123');
       expect(router.findRoute('foo.bar').parameters['bar'], '321');
     });
@@ -500,25 +529,41 @@ commonProviderTests(RouterFactory routerFactory) {
       await router.route('/123?foo=bar&blah=blah');
       expect(counters,
           {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 0, 'barEnter': 0});
-      expect(router.findRoute('foo').queryParameters,
-          {'foo': 'bar', 'blah': 'blah',});
+      expect(router.findRoute('foo').queryParameters, {
+        'foo': 'bar',
+        'blah': 'blah',
+      });
       await router.reload();
-      expect(router.findRoute('foo').queryParameters,
-          {'foo': 'bar', 'blah': 'blah',});
+      expect(router.findRoute('foo').queryParameters, {
+        'foo': 'bar',
+        'blah': 'blah',
+      });
     });
 
     test('should preserve query param values on reload from the middle',
         () async {
       await router.route('/123/321?foo=bar&blah=blah');
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 0, 'barEnter': 1,});
-      expect(router.findRoute('foo').queryParameters,
-          {'foo': 'bar', 'blah': 'blah',});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 0,
+        'barEnter': 1,
+      });
+      expect(router.findRoute('foo').queryParameters, {
+        'foo': 'bar',
+        'blah': 'blah',
+      });
       await router.reload(startingFrom: router.findRoute('foo'));
-      expect(counters,
-          {'fooLeave': 0, 'fooEnter': 1, 'barLeave': 1, 'barEnter': 2,});
-      expect(router.findRoute('foo').queryParameters,
-          {'foo': 'bar', 'blah': 'blah',});
+      expect(counters, {
+        'fooLeave': 0,
+        'fooEnter': 1,
+        'barLeave': 1,
+        'barEnter': 2,
+      });
+      expect(router.findRoute('foo').queryParameters, {
+        'foo': 'bar',
+        'blah': 'blah',
+      });
       expect(router.findRoute('foo').parameters['foo'], '123');
       expect(router.findRoute('foo.bar').parameters['bar'], '321');
     });
@@ -1286,7 +1331,9 @@ commonProviderTests(RouterFactory routerFactory) {
               name: 'foo',
               path: '/:foo',
               enter: expectAsync((RouteEvent e) {
-                expect(e.parameters, {'foo': '123',});
+                expect(e.parameters, {
+                  'foo': '123',
+                });
                 expect(e.queryParameters, {'a': 'b', 'b': '', 'c': 'foo bar'});
               }));
 
@@ -1294,7 +1341,10 @@ commonProviderTests(RouterFactory routerFactory) {
       });
 
       test('should not reload when unwatched query param changes', () async {
-        var counters = {'fooLeave': 0, 'fooEnter': 0,};
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
         router.root
           ..addRoute(
               name: 'foo',
@@ -1304,13 +1354,22 @@ commonProviderTests(RouterFactory routerFactory) {
               enter: (_) => counters['fooEnter']++);
 
         await router.route('/123');
-        expect(counters, {'fooLeave': 0, 'fooEnter': 1,});
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+        });
         await router.route('/123?foo=bar');
-        expect(counters, {'fooLeave': 0, 'fooEnter': 1,});
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+        });
       });
 
       test('should reload when watched query param changes', () async {
-        var counters = {'fooLeave': 0, 'fooEnter': 0,};
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
         router.root
           ..addRoute(
               name: 'foo',
@@ -1320,13 +1379,22 @@ commonProviderTests(RouterFactory routerFactory) {
               enter: (_) => counters['fooEnter']++);
 
         await router.route('/123');
-        expect(counters, {'fooLeave': 0, 'fooEnter': 1,});
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+        });
         await router.route('/123?foo=bar');
-        expect(counters, {'fooLeave': 1, 'fooEnter': 2,});
+        expect(counters, {
+          'fooLeave': 1,
+          'fooEnter': 2,
+        });
       });
 
       test('should match pattern for watched query params', () async {
-        var counters = {'fooLeave': 0, 'fooEnter': 0,};
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
         router.root
           ..addRoute(
               name: 'foo',
@@ -1336,9 +1404,15 @@ commonProviderTests(RouterFactory routerFactory) {
               enter: (_) => counters['fooEnter']++);
 
         await router.route('/123');
-        expect(counters, {'fooLeave': 0, 'fooEnter': 1,});
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+        });
         await router.route('/123?foo=bar');
-        expect(counters, {'fooLeave': 1, 'fooEnter': 2,});
+        expect(counters, {
+          'fooLeave': 1,
+          'fooEnter': 2,
+        });
       });
     });
 

--- a/test/route_handle_test.dart
+++ b/test/route_handle_test.dart
@@ -40,17 +40,37 @@ main() {
       routeHandle.onEnter.listen((_) => counters['Enter']++);
       routeHandle.onLeave.listen((_) => counters['Leave']++);
 
-      expect(counters, {'PreEnter': 0, 'PreLeave': 0, 'Enter': 0, 'Leave': 0,});
+      expect(counters, {
+        'PreEnter': 0,
+        'PreLeave': 0,
+        'Enter': 0,
+        'Leave': 0,
+      });
 
       await router.route('/foo');
-      expect(counters, {'PreEnter': 1, 'PreLeave': 0, 'Enter': 1, 'Leave': 0,});
+      expect(counters, {
+        'PreEnter': 1,
+        'PreLeave': 0,
+        'Enter': 1,
+        'Leave': 0,
+      });
 
       await router.route('/bar');
-      expect(counters, {'PreEnter': 1, 'PreLeave': 1, 'Enter': 1, 'Leave': 1,});
+      expect(counters, {
+        'PreEnter': 1,
+        'PreLeave': 1,
+        'Enter': 1,
+        'Leave': 1,
+      });
 
       routeHandle.discard();
       await router.route('/foo');
-      expect(counters, {'PreEnter': 1, 'PreLeave': 1, 'Enter': 1, 'Leave': 1,});
+      expect(counters, {
+        'PreEnter': 1,
+        'PreLeave': 1,
+        'Enter': 1,
+        'Leave': 1,
+      });
     });
 
     test('should return valid RouteHandles for child routes', () {

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -78,16 +78,27 @@ main() {
       tmpl = new UrlTemplate(':a/bar/baz');
       expect(tmpl.urlParameterNames, equals(['a']));
       expect(tmpl.reverse(), 'null/bar/baz');
-      expect(tmpl.reverse(parameters: {'a': '/foo',}), '/foo/bar/baz');
+      expect(
+          tmpl.reverse(parameters: {
+            'a': '/foo',
+          }),
+          '/foo/bar/baz');
 
       tmpl = new UrlTemplate('/foo/bar/:c');
       expect(tmpl.urlParameterNames, equals(['c']));
       expect(tmpl.reverse(), '/foo/bar/null');
-      expect(tmpl.reverse(parameters: {'c': 'baz',}), '/foo/bar/baz');
+      expect(
+          tmpl.reverse(parameters: {
+            'c': 'baz',
+          }),
+          '/foo/bar/baz');
 
       tmpl = new UrlTemplate('/foo/bar/:c');
       expect(tmpl.urlParameterNames, equals(['c']));
-      expect(tmpl.reverse(tail: '/tail', parameters: {'c': 'baz',}),
+      expect(
+          tmpl.reverse(tail: '/tail', parameters: {
+            'c': 'baz',
+          }),
           '/foo/bar/baz/tail');
     });
 


### PR DESCRIPTION
### Issue

When a route change occurs, there is logic to call `_history.back();` if a route change is rejected by either `preLeave` or `preEnter`:

``` dart
_history.onChange.listen((_) {
    // only route if the new url isn't already active
    if (activeUrl != _history.path) {
      _logger.finest('listen triggered. activeUrl=$activeUrl history path= ${_history.path}');
      route(_history.path).then((allowed) {
        // if not allowed, we need to restore the browser location
        if (!allowed) {
          _history.back();
        }
  ...
});
```

However, when the router first starts up it simply calls `route()` and does not handle the result:

``` dart
route(_history.path);
```

Because of this, if a user pastes the URL to a route that would be rejected, 
1. the address bar stays at the rejected url
2. the router gets into a bad state, hosing all future route calls
### Changes

**Source:**
- Handle a `false` result from the initial `route()` call.

**Tests:**
- Add new unit test for this scenario
### Testing
- CI Passes
### Code Review

@Workiva/client-platform-pp
