### PR TITLE
CP-1715 Release route.dart 0.10.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: route_hierarchical
-version: 0.10.0
+version: 0.10.1
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>


### PR DESCRIPTION
Pulls Included in Release:
- [CP-2673 Handle initial route being rejected by preEnter](https://github.com/Workiva/route.dart/pull/22)

Requested by: charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/route.dart/compare/0.10.0...version-bump-route-dart-0-10-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/route.dart/compare/0.10.0...0.10.1
