### PR TITLE
CP-2934 Adding smithy.yaml and pinning dart-sdk version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pubspec.lock
 .pub/
 .buildlog
 build/
+coverage/
 /node_modules/
 /test/out/
 /npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.19.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0
@@ -9,5 +9,5 @@ script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-#  - pub run dart_dev coverage --no-html
-#  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  - pub run dart_dev coverage --no-html
+  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION
## Issue
- We needed to add a smithy.yaml for release management to more easily track dependencies. BONUS, pinned dart-sdk in .travis.yaml and re-enabled coverage

## Changes
**Source:**
- Included smithy.yaml
- Updated .travis.yaml

**Tests:**
- n/a

## Areas of Regression
- passing CI's

## Testing
- passing CI

## Code Review
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
@sebastianmalysa-wf 