### PR TITLE
WP-4684 Release route.dart 0.10.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: route_hierarchical
-version: 0.10.3
+version: 0.10.4
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4873 Fix DDC Test Failures](https://github.com/Workiva/route.dart/pull/31)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/route.dart/compare/0.10.3...version-bump-route-dart-0-10-4
Diff Between Last Tag and New Tag: https://github.com/Workiva/route.dart/compare/0.10.3...0.10.4